### PR TITLE
HOTFIX: Fix composer branch reference after merged PRs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "drupal/twig_debugger": "^1.1",
         "drupal/uswds": "^3",
         "drush/drush": "^12.5",
-        "uvalib/cd-finder-uva": "dev-feature/share-link-functionality",
+        "uvalib/cd-finder-uva": "dev-master",
         "uvalib/uva_dsf_uswds": "dev-main"
     },
     "require-dev": {


### PR DESCRIPTION
## 🚨 Critical Hotfix Required

### Problem
After merging PRs #9 and uvalib/CD-finder-uva#1, the composer.json still references the feature branch instead of the stable master branch.

### Current State (BROKEN)
```json
"uvalib/cd-finder-uva": "dev-feature/share-link-functionality"
```

### Fixed State 
```json  
"uvalib/cd-finder-uva": "dev-master"
```

### Why This Is Critical
- **Deployment will fail**: Feature branch may be deleted after PR cleanup
- **Dependency resolution broken**: Composer can't find the reference after branch cleanup
- **Production stability**: Need to reference the stable master branch
- **Future updates blocked**: All composer updates will fail until this is fixed

### Impact Without Fix
- ❌ `composer update` commands will fail
- ❌ New deployments will break
- ❌ Dependency management becomes unstable
- ❌ Other developers can't work with the repository

### Verification Steps
After merging this hotfix:
```bash
composer update uvalib/cd-finder-uva --no-dev
# Should successfully pull from master branch
```

### Related Context
This fix should have been included in PR #9 but was committed after the merge occurred. This hotfix ensures the production deployment references the correct stable branch.

---
**Priority**: URGENT - Required for deployment stability  
**Risk**: LOW - Single line change with clear intent  
**Testing**: Composer update verification sufficient